### PR TITLE
Cache expiry bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.idea

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ The pluginArgs used by kafka-offset-monitor-graphite are:
 - **graphitePort** Graphite reporting port (default 2003)
 - **graphitePrefix** Metrics prefix (default stats.kafka.offset.monitor)
 - **graphiteReportPeriod** Reporting period in seconds (default 30)
-- **metricsCacheExpireMinutes** Metrics cache TTL in mires (default 10). Offset metrics are stored in expiring cache and reported to Graphite periodically. If metrics are not updated they will be removed.
+- **metricsCacheExpireSeconds** Metrics cache TTL in mires (default 600). Offset metrics are stored in expiring cache and reported to Graphite periodically. If metrics are not updated they will be removed.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,7 +23,10 @@ object KafkaUtilsBuild extends Build {
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "18.0",
       "com.quantifind" % "kafkaoffsetmonitor_2.10" % "0.3.0-SNAPSHOT",
-      "io.dropwizard.metrics" % "metrics-graphite" % "3.1.0"
+      "io.dropwizard.metrics" % "metrics-graphite" % "3.1.0",
+
+      "org.scalatest" % "scalatest_2.10" % "2.2.4" % "test",
+      "com.jayway.awaitility" % "awaitility" % "1.6.1" % "test"
     ),
 
     excludedJars in assembly := {

--- a/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/GraphiteReporterArguments.scala
+++ b/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/GraphiteReporterArguments.scala
@@ -12,7 +12,7 @@ object GraphiteReporterArguments {
 
   var graphiteReportPeriod : Int = 30
 
-  var metricsCacheExpireSeconds : Int = 10
+  var metricsCacheExpireSeconds : Int = 600
 
   def parseArguments(args: String) = {
     val argsMap: Map[String, String] = args.split(",").map(_.split("=", 2)).filter(_.length > 1).map(arg => { arg(0) -> arg(1) }).toMap

--- a/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/GraphiteReporterArguments.scala
+++ b/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/GraphiteReporterArguments.scala
@@ -12,7 +12,7 @@ object GraphiteReporterArguments {
 
   var graphiteReportPeriod : Int = 30
 
-  var metricsCacheExpireMinutes : Int = 10
+  var metricsCacheExpireSeconds : Int = 10
 
   def parseArguments(args: String) = {
     val argsMap: Map[String, String] = args.split(",").map(_.split("=", 2)).filter(_.length > 1).map(arg => { arg(0) -> arg(1) }).toMap
@@ -20,6 +20,6 @@ object GraphiteReporterArguments {
     argsMap.get("graphitePort").foreach(str => {graphitePort = parseInt(str)})
     argsMap.get("graphitePrefix").foreach(graphitePrefix = _)
     argsMap.get("graphiteReportPeriod").foreach(str => {graphiteReportPeriod = parseInt(str)})
-    argsMap.get("metricsCacheExpireMinutes").foreach(str => {metricsCacheExpireMinutes = parseInt(str)})
+    argsMap.get("metricsCacheExpireSeconds").foreach(str => {metricsCacheExpireSeconds = parseInt(str)})
   }
 }

--- a/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/OffsetGraphiteReporter.scala
+++ b/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/OffsetGraphiteReporter.scala
@@ -27,12 +27,14 @@ class OffsetGraphiteReporter (pluginsArgs: String) extends com.quantifind.kafka.
 
   val removalListener : RemovalListener[String, GaugesValues] = new RemovalListener[String, GaugesValues] {
     override def onRemoval(removalNotification: RemovalNotification[String, GaugesValues]) = {
-      metrics.remove(removalNotification.getKey())
+      metrics.remove(removalNotification.getKey() + ".offset")
+      metrics.remove(removalNotification.getKey() + ".logSize")
+      metrics.remove(removalNotification.getKey() + ".lag")
     }
   }
 
   val gauges : LoadingCache[String, GaugesValues] = CacheBuilder.newBuilder()
-    .expireAfterAccess(GraphiteReporterArguments.metricsCacheExpireMinutes, TimeUnit.MINUTES)
+    .expireAfterAccess(GraphiteReporterArguments.metricsCacheExpireSeconds, TimeUnit.SECONDS)
     .removalListener(removalListener)
     .build(
       new CacheLoader[String, GaugesValues]() {
@@ -78,5 +80,4 @@ class OffsetGraphiteReporter (pluginsArgs: String) extends com.quantifind.kafka.
   def getMetricName(offsetInfo: OffsetInfo): String = {
     offsetInfo.topic.replace(".", "_") + "." + offsetInfo.group.replace(".", "_") + "." + offsetInfo.partition
   }
-
 }

--- a/src/test/scala/pl/allegro/tech/kafka/offset/monitor/graphite/GraphiteMockServer.scala
+++ b/src/test/scala/pl/allegro/tech/kafka/offset/monitor/graphite/GraphiteMockServer.scala
@@ -1,0 +1,76 @@
+package pl.allegro.tech.kafka.offset.monitor.graphite
+
+import java.io.InputStream
+import java.lang
+import java.net.ServerSocket
+import java.util.concurrent.{Callable, ExecutorService, Executors}
+
+import com.jayway.awaitility.Awaitility._
+import com.jayway.awaitility.Duration
+
+class GraphiteMockServer(port: Int) {
+
+  var serverSocket: ServerSocket = null
+  val executor: ExecutorService = Executors.newFixedThreadPool(10)
+  @volatile var listen: Boolean = false
+
+  var expectedMetrics: scala.collection.mutable.Map[String, Double] = scala.collection.mutable.Map()
+  var receivedMetrics: scala.collection.mutable.Map[String, Double] = scala.collection.mutable.Map()
+  
+  def start() {
+    serverSocket = new ServerSocket(port)
+    listen = true
+    handleConnections()
+  }
+
+  private def handleConnections() {
+    executor.execute(new Runnable {
+      override def run() {
+        while(listen) {
+            readData(serverSocket.accept().getInputStream())
+        }
+      }
+    })
+  }
+
+  private def readData(stream: InputStream) {
+    executor.execute(new Runnable {
+      override def run() {
+        scala.io.Source.fromInputStream(stream).getLines().foreach((line) => handleMetric(line))
+      }
+    })
+  }
+  
+  private def handleMetric(metricLine: String) {
+    val metric = metricLine.split(" ")(0)
+    val value = metricLine.split(" ")(1)
+
+    if(expectedMetrics.contains(metric)) {
+      receivedMetrics += (metric -> value.toDouble)
+    }
+  }
+  
+  def stop() {
+    listen = false
+    serverSocket.close()
+  }
+  
+  def reset() {
+    expectedMetrics.clear()
+    receivedMetrics.clear()
+  }
+
+  def expectMetric(metricNamePattern: String, value: Double) {
+    expectedMetrics += (metricNamePattern -> value)
+  }
+
+  def waitUntilReceived() {
+    await.atMost(Duration.FIVE_SECONDS).until(new Callable[lang.Boolean] {
+      override def call(): lang.Boolean = {
+        expectedMetrics.forall { case (k, v) =>
+          receivedMetrics.get(k).exists( (rv) => v == rv )
+        }
+      }
+    })
+  }
+}

--- a/src/test/scala/pl/allegro/tech/kafka/offset/monitor/graphite/OffsetGraphiteReporterTest.scala
+++ b/src/test/scala/pl/allegro/tech/kafka/offset/monitor/graphite/OffsetGraphiteReporterTest.scala
@@ -1,0 +1,63 @@
+package pl.allegro.tech.kafka.offset.monitor.graphite
+
+import com.quantifind.kafka.OffsetGetter.OffsetInfo
+import org.scalatest.{BeforeAndAfter, FlatSpec, GivenWhenThen}
+
+class OffsetGraphiteReporterTest extends FlatSpec with BeforeAndAfter with GivenWhenThen {
+  
+  val GRAPHITE_PORT = 48213
+  
+  val graphite = new GraphiteMockServer(GRAPHITE_PORT)
+  
+  val reporter = new OffsetGraphiteReporter(s"graphiteHost=localhost,graphitePort=$GRAPHITE_PORT,graphitePrefix=offset,metricsCacheExpireSeconds=1,graphiteReportPeriod=1")
+  
+  before {
+    graphite.start()
+  }
+  
+  after {
+    graphite.stop()
+  }
+  
+  it should "report metrics to graphite" in {
+    Given("offset")
+    val offset = OffsetInfo("group", "topic", 0, 10, 11, Option.empty, null, null)
+    graphite.expectMetric("offset.topic.group.0.offset", 10)
+    graphite.expectMetric("offset.topic.group.0.logSize", 11)
+    graphite.expectMetric("offset.topic.group.0.lag", 1)
+
+    When("reporting")
+    reporter.report(Array(offset))
+    
+    Then("expect metrics to be delivered")
+    graphite.waitUntilReceived()
+  }
+  
+  it should "escape names of topic and groups" in {
+    Given("offset for topic and group with dots")
+    val offset = OffsetInfo("escape.group", "escape.topic", 0, 10, 11, Option.empty, null, null)
+    
+    When("reporting")
+    graphite.expectMetric("offset.escape_topic.escape_group.0.offset", 10)
+    graphite.expectMetric("offset.escape_topic.escape_group.0.logSize", 11)
+    graphite.expectMetric("offset.escape_topic.escape_group.0.lag", 1)
+    reporter.report(Array(offset))
+
+    Then("expect metrics to be delivered")
+    graphite.waitUntilReceived()
+  }
+  
+  it should "not fail to recreate metrics after cache has expired" in {
+    Given("offset")
+    val offset = OffsetInfo("expired_group", "expired_topic", 0, 10, 11, Option.empty, null, null)
+    reporter.report(Array(offset))
+    
+    When("waiting for cache to expire and reporting again")
+    Thread.sleep(2000)
+    graphite.expectMetric("offset.expired_topic.expired_group.0.offset", 10)
+    reporter.report(Array(offset))
+
+    Then("expect metrics to be delivered")
+    graphite.waitUntilReceived()
+  }
+}


### PR DESCRIPTION
Solving #1 and added e2e tests with mock graphite. To reproduce the bug, run test suite on unmodified `OffsetGraphiteReporter`. Changed unit of time for cache expiry to be able to test this code in some finite time. Time unit doesn't matter that much.
