### PR TITLE
Bump dropwizard to 3.1.2 to avoid https://github.com/dropwizard/metri…

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,7 +23,7 @@ object KafkaUtilsBuild extends Build {
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "18.0",
       "com.quantifind" % "kafkaoffsetmonitor_2.10" % "0.3.0-SNAPSHOT",
-      "io.dropwizard.metrics" % "metrics-graphite" % "3.1.0",
+      "io.dropwizard.metrics" % "metrics-graphite" % "3.1.2",
 
       "org.scalatest" % "scalatest_2.10" % "2.2.4" % "test",
       "com.jayway.awaitility" % "awaitility" % "1.6.1" % "test"


### PR DESCRIPTION
I ran into https://github.com/dropwizard/metrics/issues/694 and seem to be able to work around by using the latest 3.1.2 release. Originally, a connection failure would cause my monitor to stop populating graphite. Now, while I still see occasional connection failures in logs, graphite continues to populate.
